### PR TITLE
Render tree using TreeNode.toString

### DIFF
--- a/src/main/java/com/pengyifan/commons/lang/string/TreeString.java
+++ b/src/main/java/com/pengyifan/commons/lang/string/TreeString.java
@@ -46,7 +46,7 @@ public class TreeString {
       } else {
         sb.append(StringUtils.END + " ");
       }
-      sb.append(tn.getObject() + "\n");
+      sb.append(tn + "\n");
 
     }
 


### PR DESCRIPTION
I don't think there is a good reason why TreeString.toString() doesn't use TreeNode.toString(). Doing so allows seperation between the object's toString() and a human description like this:

```java
return new TreeNode( trade ) {
            @Override
            public String toString() {
                return description;
            }
};
```

Thanks, Marc