### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/pengyifan/commons/collections/ImmutableCollectors.java
+++ b/src/main/java/com/pengyifan/commons/collections/ImmutableCollectors.java
@@ -25,8 +25,11 @@ import com.google.common.collect.ImmutableSet;
  *     .collect(ImmutableCollectors.toSet());
  * </pre>
  */
-public class ImmutableCollectors {
+public final class ImmutableCollectors {
 
+  private ImmutableCollectors() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new
    * {@code ImmutableList}.

--- a/src/main/java/com/pengyifan/commons/collections/ListUtils.java
+++ b/src/main/java/com/pengyifan/commons/collections/ListUtils.java
@@ -5,8 +5,11 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-public class ListUtils {
+public final class ListUtils {
 
+  private ListUtils() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
   /**
    * Given a sequence of s1,...,sn, find the first subsequence si1 < si2 < ...<
    * sik with i1 < ... < ik so that k is as large as possible.

--- a/src/main/java/com/pengyifan/commons/collections/MyIterables.java
+++ b/src/main/java/com/pengyifan/commons/collections/MyIterables.java
@@ -8,7 +8,12 @@ import java.util.AbstractList;
  * This class contains static utility methods that operate on or return objects
  * of type Iterable.
  */
-public class MyIterables {
+public final class MyIterables {
+
+  private MyIterables() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
+
   /**
    * Creates an iterable combining the first element and an array
    * 

--- a/src/main/java/com/pengyifan/commons/collections/Pairs.java
+++ b/src/main/java/com/pengyifan/commons/collections/Pairs.java
@@ -6,7 +6,11 @@ import org.javatuples.Pair;
 import java.util.Collection;
 import java.util.List;
 
-public class Pairs {
+public final class Pairs {
+
+  private Pairs() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
 
   public static <E> Collection<Pair<E, E>> getPairs(Collection<E> set) {
     List<Pair<E, E>> pairs = Lists.newArrayList();

--- a/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeapString.java
+++ b/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeapString.java
@@ -2,7 +2,11 @@ package com.pengyifan.commons.collections.heap;
 
 import com.pengyifan.commons.lang.StringUtils;
 
-public class FibonacciHeapString {
+public final class FibonacciHeapString {
+
+  private FibonacciHeapString() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
 
   public static StringBuilder toString(FibonacciHeap heap, StringBuilder sb) {
     if (heap.minimum() == null) {

--- a/src/main/java/com/pengyifan/commons/io/FileUtils2.java
+++ b/src/main/java/com/pengyifan/commons/io/FileUtils2.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.Validate;
 
-public class FileUtils2 {
+public final class FileUtils2 {
 
   private static final FileFilter ACCEPT_ALL = new FileFilter() {
 
@@ -25,6 +25,10 @@ public class FileUtils2 {
       return true;
     }
   };
+
+  private FileUtils2() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");    
+  }
 
   public static void mergeFile(File destination, List<File> sources)
       throws IOException {

--- a/src/main/java/com/pengyifan/commons/lang/FromStringBuilder.java
+++ b/src/main/java/com/pengyifan/commons/lang/FromStringBuilder.java
@@ -9,10 +9,14 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class FromStringBuilder {
+public final class FromStringBuilder {
 
   private static final Pattern pattern = Pattern
       .compile("([a-z]+)=\"([^\"]+|\")\"");
+
+  private FromStringBuilder() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");    
+  }
 
   /**
    * Parses a string formatted with toStringBuilder

--- a/src/main/java/com/pengyifan/commons/lang/StringUtils.java
+++ b/src/main/java/com/pengyifan/commons/lang/StringUtils.java
@@ -11,6 +11,10 @@ public class StringUtils {
   // ├
   public static final String MIDDLE = bar(3);
 
+  private StringUtils() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
+
   private static String bar(int i) {
     try {
       switch (i) {

--- a/src/main/java/com/pengyifan/commons/math/MatrixUtils2.java
+++ b/src/main/java/com/pengyifan/commons/math/MatrixUtils2.java
@@ -12,7 +12,11 @@ import org.apache.commons.math3.linear.RealMatrix;
 
 import Jama.Matrix;
 
-public class MatrixUtils2 {
+public final class MatrixUtils2 {
+
+  private MatrixUtils2() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");    
+  }
 
   public static String printInOneline(String[][] matrix) {
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/pengyifan/commons/math/RangeUtils.java
+++ b/src/main/java/com/pengyifan/commons/math/RangeUtils.java
@@ -6,7 +6,11 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.Range;
 import org.apache.commons.lang3.Validate;
 
-public class RangeUtils {
+public final class RangeUtils {
+  
+  private RangeUtils() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");    
+  }
 
   /**
    * Returns true if range1 &le; range2.

--- a/src/main/java/com/pengyifan/commons/math/StatUtils2.java
+++ b/src/main/java/com/pengyifan/commons/math/StatUtils2.java
@@ -6,6 +6,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class StatUtils2 {
 
+  private StatUtils2() throws InstantiationException {
+    throw new InstantiationException("This class is not for instantiation");
+  }
+
   public static double mean(double[] data, double[] weights) {
     checkArgument(data.length == weights.length);
     DescriptiveStatistics stats = new DescriptiveStatistics();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat