### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the var…

### DIFF
--- a/src/main/java/com/pengyifan/commons/collections/ListUtils.java
+++ b/src/main/java/com/pengyifan/commons/collections/ListUtils.java
@@ -39,12 +39,12 @@ public final class ListUtils {
     /**
      * length of longest increasing subsequence in s1,...,sn that ends in si
      */
-    int l[] = new int[list.size()];
+    int[] l = new int[list.size()];
     /**
      * by following the p[j] values we can reconstruct the whole sequence in
      * linear time.
      */
-    int p[] = new int[list.size()];
+    int[] p = new int[list.size()];
     for (int j = 0; j < list.size(); j++) {
       E sj = list.get(j);
       l[j] = 1;

--- a/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeap.java
+++ b/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeap.java
@@ -244,7 +244,7 @@ public class FibonacciHeap<E> {
 
     // Initialize array by making each entry NIL.
     int arraySize = ((int) Math.floor(Math.log(n) * oneOverLogPhi)) + 1;
-    Entry<E> array[] = ErasureUtils.mkTArray(min.getClass(), arraySize);
+    Entry<E>[] array = ErasureUtils.mkTArray(min.getClass(), arraySize);
 
     if (min != null) {
       for (Entry<E> w : min.nodelist()) {

--- a/src/main/java/com/pengyifan/commons/collections/tree/TreeUtils.java
+++ b/src/main/java/com/pengyifan/commons/collections/tree/TreeUtils.java
@@ -38,7 +38,7 @@ public class TreeUtils {
    * <i>t</i>.
    */
   public static <E, T extends Tree<E, T>> int leftEdge(T t, T root) {
-    int i[] = new int[] { 0 };
+    int[] i = new int[]{0};
     if (leftEdge(t, root, i)) {
       return i[0];
     } else {
@@ -46,7 +46,7 @@ public class TreeUtils {
     }
   }
 
-  static <E, T extends Tree<E, T>> boolean leftEdge(T t, T t1, int i[]) {
+  static <E, T extends Tree<E, T>> boolean leftEdge(T t, T t1, int[] i) {
     if (t == t1) {
       return true;
     } else if (t1.isLeaf()) {
@@ -69,7 +69,7 @@ public class TreeUtils {
    * <i>t</i> plus all the material contained in <i>t</i>.
    */
   public static <E, T extends Tree<E, T>> int rightEdge(T t, T root) {
-    int i[] = new int[] { root.getLeaves().size() };
+    int[] i = new int[]{root.getLeaves().size()};
     if (rightEdge(t, root, i)) {
       return i[0];
     } else {
@@ -78,7 +78,7 @@ public class TreeUtils {
     }
   }
 
-  static <E, T extends Tree<E, T>> boolean rightEdge(T t, T t1, int i[]) {
+  static <E, T extends Tree<E, T>> boolean rightEdge(T t, T t1, int[] i) {
     if (t == t1) {
       return true;
     } else if (t1.isLeaf()) {

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMPrintStream.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMPrintStream.java
@@ -58,7 +58,7 @@ public class LibSVMPrintStream implements Closeable {
     ps.println(sb);
   }
 
-  public void printRow(int label, int row[]) {
+  public void printRow(int label, int[] row) {
     StringBuilder sb = new StringBuilder()
         .append(label);// label
     // kernel
@@ -86,7 +86,7 @@ public class LibSVMPrintStream implements Closeable {
    * @param row svm instance
    * @param rowNumber starts at 1
    */
-  public void printPrecomputedRow(int label, double row[], int rowNumber) {
+  public void printPrecomputedRow(int label, double[] row, int rowNumber) {
     StringBuilder sb = new StringBuilder()
         .append(label)// label
         .append(" 0:" + (rowNumber));// ID
@@ -97,7 +97,7 @@ public class LibSVMPrintStream implements Closeable {
     ps.println(sb);
   }
 
-  public void printPrecomputedRow(int label, int row[], int rowNumber) {
+  public void printPrecomputedRow(int label, int[] row, int rowNumber) {
     StringBuilder sb = new StringBuilder()
         .append(label)// label
         .append(" 0:" + rowNumber);// ID


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat