### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/src/main/java/com/pengyifan/commons/collections/tree/Tree.java
+++ b/src/main/java/com/pengyifan/commons/collections/tree/Tree.java
@@ -510,7 +510,7 @@ public class Tree<E, T extends Tree<E, T>> implements Iterable<T> {
    * @return true if this node has no children
    */
   public boolean isLeaf() {
-    return (getChildCount() == 0);
+    return getChildCount() == 0;
   }
 
   /**
@@ -552,7 +552,7 @@ public class Tree<E, T extends Tree<E, T>> implements Iterable<T> {
     } else if (getChildCount() == 0) {
       val = false;
     } else {
-      val = (child.getParent() == this);
+      val = child.getParent() == this;
     }
 
     return val;
@@ -572,7 +572,7 @@ public class Tree<E, T extends Tree<E, T>> implements Iterable<T> {
     } else if (t == this) {
       val = true;
     } else {
-      val = (parent != null && parent == t.getParent());
+      val = parent != null && parent == t.getParent();
       checkArgument(!val || parent.isNodeChild(t), "The siblings have different parents");
     }
     return val;
@@ -874,7 +874,7 @@ public class Tree<E, T extends Tree<E, T>> implements Iterable<T> {
 
     @Override
     public boolean hasNext() {
-      return (!stack.empty() && stack.peek().hasNext());
+      return !stack.empty() && stack.peek().hasNext();
     }
 
     @Override

--- a/src/main/java/com/pengyifan/commons/math/SparseRealVector.java
+++ b/src/main/java/com/pengyifan/commons/math/SparseRealVector.java
@@ -92,7 +92,7 @@ public class SparseRealVector {
         v.dimension);
     return map.keySet().parallelStream().map(index -> {
       double vvalue = v.getEntry(index);
-      return (Precision.equals(vvalue, DEFAULT_VALUE, PRECISION))
+      return Precision.equals(vvalue, DEFAULT_VALUE, PRECISION)
           ?
           0 :
           getEntry(index) * v.getEntry(index);

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainerClient.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainerClient.java
@@ -69,7 +69,7 @@ public class LibSVMTrainerClient {
       System.err.print("NaN or Infinity in input\n");
       System.exit(1);
     }
-    return (d);
+    return d;
   }
 
   private void parseCommandLine(String[] argv) {

--- a/src/main/java/com/pengyifan/util/regex/RegExpState.java
+++ b/src/main/java/com/pengyifan/util/regex/RegExpState.java
@@ -163,7 +163,7 @@ class RegExpState {
     }
     RegExpState rhs = (RegExpState) obj;
     if (nfaStates.isEmpty())
-      return (stateID == rhs.stateID);
+      return stateID == rhs.stateID;
     else return Objects.equals(nfaStates, rhs.nfaStates);
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat