### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/main/java/com/pengyifan/commons/chain/Chain.java
+++ b/src/main/java/com/pengyifan/commons/chain/Chain.java
@@ -6,9 +6,9 @@ import com.google.common.annotations.VisibleForTesting;
 
 public class Chain {
   @VisibleForTesting
-  Handler headHandler;
+  protected Handler headHandler;
   @VisibleForTesting
-  Handler tailHandler;
+  protected Handler tailHandler;
 
   /**
    * Appends the handler to the end of this list.

--- a/src/main/java/com/pengyifan/commons/collections/counter/Counter.java
+++ b/src/main/java/com/pengyifan/commons/collections/counter/Counter.java
@@ -219,7 +219,7 @@ public abstract class Counter<K> {
       public Iterator<Entry<K, Integer>> iterator() {
         return new Iterator<Entry<K, Integer>>() {
 
-          final Iterator<Entry<K, MutableInteger>> inner = map.entrySet()
+          private final Iterator<Entry<K, MutableInteger>> inner = map.entrySet()
               .iterator();
 
           @Override
@@ -231,7 +231,7 @@ public abstract class Counter<K> {
           public Entry<K, Integer> next() {
             return new Map.Entry<K, Integer>() {
 
-              final Entry<K, MutableInteger> e = inner.next();
+              private final Entry<K, MutableInteger> e = inner.next();
 
               @Override
               public K getKey() {

--- a/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeap.java
+++ b/src/main/java/com/pengyifan/commons/collections/heap/FibonacciHeap.java
@@ -390,43 +390,43 @@ public class FibonacciHeap<E> {
     /**
      * Any one of its children
      */
-    Entry<E> child;
+    protected Entry<E> child;
 
     /**
      * Left sibling
      */
-    Entry<E> left;
+    private Entry<E> left;
 
     /**
      * Its parent
      */
-    Entry<E> parent;
+    protected Entry<E> parent;
 
     /**
      * Right sibling
      */
-    Entry<E> right;
+    protected Entry<E> right;
 
     /**
      * Whether this node has lost a child since the last time this node was
      * made the child of another node.
      */
-    boolean mark;
+    private boolean mark;
 
     /**
      * Key for this node
      */
-    int key;
+    protected int key;
 
     /**
      * Value for this node
      */
-    E obj;
+    private E obj;
 
     /**
      * The number of children in the child list
      */
-    int degree;
+    private int degree;
 
     /**
      * Returns the key corresponding to this entry.

--- a/src/main/java/com/pengyifan/util/regex/RegExpMatcher.java
+++ b/src/main/java/com/pengyifan/util/regex/RegExpMatcher.java
@@ -16,7 +16,7 @@ public class RegExpMatcher {
   /**
    * The Pattern object that created this Matcher.
    */
-  RegExpPattern pattern;
+  private RegExpPattern pattern;
 
   /**
    * Contains the current patterns accessed


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat