### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both t…

### DIFF
--- a/src/main/java/com/pengyifan/commons/collections/counter/HashCounter.java
+++ b/src/main/java/com/pengyifan/commons/collections/counter/HashCounter.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 /**
  * @deprecated Use {@link com.google.common.collect.HashMultiset} instead.
  */
+@Deprecated
 public class HashCounter<K> extends Counter<K> {
 
   /**

--- a/src/main/java/com/pengyifan/commons/collections/counter/TreeCounter.java
+++ b/src/main/java/com/pengyifan/commons/collections/counter/TreeCounter.java
@@ -6,6 +6,7 @@ import java.util.TreeMap;
 /**
  * @deprecated Use {@link com.google.common.collect.TreeMultiset} instead.
  */
+@Deprecated
 public class TreeCounter<K> extends Counter<K> {
 
   /**

--- a/src/main/java/com/pengyifan/commons/io/BatchProcessor.java
+++ b/src/main/java/com/pengyifan/commons/io/BatchProcessor.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.Validate;
  * @author Yifan Peng
  * @deprecated Use {@code AbstractBatchProcessor} instead
  */
+@Deprecated
 public abstract class BatchProcessor {
 
   private final File path;

--- a/src/main/java/com/pengyifan/commons/io/BatchTextProcessor.java
+++ b/src/main/java/com/pengyifan/commons/io/BatchTextProcessor.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.filefilter.FileFilterUtils;
  * @deprecated Use {@code AbstractBatchProcessor} and {@code BasenameUtils}
  *             instead
  */
+@Deprecated
 public class BatchTextProcessor extends BatchProcessor {
 
   public final static FileFilter TEXT_FILTER = FileFilterUtils

--- a/src/main/java/com/pengyifan/commons/lang/XmlFormatter.java
+++ b/src/main/java/com/pengyifan/commons/lang/XmlFormatter.java
@@ -22,6 +22,7 @@ import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 /**
  * @deprecated Not really useful.
  */
+@Deprecated
 public class XmlFormatter {
 
   public static XmlFormatter newFormatter() {

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMPredict.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMPredict.java
@@ -16,6 +16,9 @@ import libsvm.svm_parameter;
 
 import org.apache.commons.lang3.Validate;
 
+/**
+ * @deprecated Not really useful.
+ */
 @Deprecated
 public class LibSVMPredict {
 

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMPredictClient.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMPredictClient.java
@@ -11,6 +11,9 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.ParserProperties;
 
+/**
+ * @deprecated Not really useful.
+ */
 @Deprecated
 public class LibSVMPredictClient {
 

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainer.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainer.java
@@ -15,6 +15,9 @@ import libsvm.svm_problem;
 
 import org.apache.commons.lang3.Validate;
 
+/**
+ * @deprecated Not really useful.
+ */
 @Deprecated
 public class LibSVMTrainer {
 

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainerClient.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainerClient.java
@@ -7,6 +7,9 @@ import libsvm.svm;
 import libsvm.svm_parameter;
 import libsvm.svm_print_interface;
 
+/**
+ * @deprecated Not really useful.
+ */
 @Deprecated
 public class LibSVMTrainerClient {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck

Please let me know if you have any questions.

M-Ezzat