### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMPredict.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMPredict.java
@@ -2,10 +2,12 @@ package com.pengyifan.kernel.svm;
 
 import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
 
@@ -108,7 +110,8 @@ public class LibSVMPredict {
     double error = 0;
     double sumv = 0, sumy = 0, sumvv = 0, sumyy = 0, sumvy = 0;
 
-    LineNumberReader reader = new LineNumberReader(new FileReader(inputFile));
+    FileInputStream fileInputStream = new FileInputStream(inputFile);
+    LineNumberReader reader = new LineNumberReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8));
     String line;
     while ((line = reader.readLine()) != null) {
       StringTokenizer st = new StringTokenizer(line, " \t\n\r\f:");

--- a/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainer.java
+++ b/src/main/java/com/pengyifan/kernel/svm/LibSVMTrainer.java
@@ -2,8 +2,10 @@ package com.pengyifan.kernel.svm;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 import java.util.Vector;
 import java.util.logging.Logger;
@@ -126,7 +128,8 @@ public class LibSVMTrainer {
     Vector<svm_node[]> vx = new Vector<>();
     int maxIndex = 0;
 
-    BufferedReader reader = new BufferedReader(new FileReader(inputFile));
+    FileInputStream fileInputStream = new FileInputStream(inputFile);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8));
     String line;
     while ((line = reader.readLine()) != null) {
       StringTokenizer st = new StringTokenizer(line, " \t\n\r\f:");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
